### PR TITLE
Fix path prefix for assets

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -15,5 +15,5 @@
     <link rel="stylesheet" type="text/css" href="https://www.section508.gov/assets/css/index.css">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/baselinealignment/assets/css/baseline.css">
+    <link rel="stylesheet" href="/assets/css/baseline.css">
 </head>

--- a/_layouts/testcase.html
+++ b/_layouts/testcase.html
@@ -52,4 +52,4 @@ provided in the document front matter; see the admin/config > collections
         </div>
     </div>
 <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"></script>
-<script src="/baselinealignment/assets/js/testcases.js"></script>
+<script src="/assets/js/testcases.js"></script>


### PR DESCRIPTION
This PR provide a path to the css and js files without the '/baselinealignment' prefix.
It is a fix for test cases pages.
https://baselinealignment.section508.gov/testcases/TC01.1-1-fail-1.html