### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete string escaping or encoding

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -11190,7 +11190,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					if (typeof result === 'string') {
 						if (thisObj.lyricsMode) {
 							// add <br> BETWEEN each caption and WITHIN each caption (if payload includes "\n")
-							result = result.replace('\n','<br>') + '<br>';
+							result = result.replace(/\n/g, '<br>') + '<br>';
 						}
 						else {
 							// just add a space between captions


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/18](https://github.com/GSA/baselinealignment/security/code-scanning/18)

To fix the issue, the `replace` method should be updated to use a regular expression with the global (`g`) flag. This ensures that all occurrences of `'\n'` in the `result` string are replaced with `<br>`. This change will preserve the intended functionality of adding `<br>` tags for every newline character in the caption payload.

**Steps to implement the fix:**
1. Replace the string argument `'\n'` in the `replace` method with a regular expression `/\n/g`.
2. Ensure that the replacement logic remains unchanged (`'<br>'`).
3. Verify that the updated code correctly handles strings with multiple newline characters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
