### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete string escaping or encoding

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -11190,7 +11190,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					if (typeof result === 'string') {
 						if (thisObj.lyricsMode) {
 							// add <br> BETWEEN each caption and WITHIN each caption (if payload includes "\n")
-							result = result.replace('\n','<br>') + '<br>';
+							result = result.replace(/\n/g,'<br>') + '<br>';
 						}
 						else {
 							// just add a space between captions

--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -11190,7 +11190,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					if (typeof result === 'string') {
 						if (thisObj.lyricsMode) {
 							// add <br> BETWEEN each caption and WITHIN each caption (if payload includes "\n")
-							result = result.replace('\n','<br>') + '<br>';
+							result = result.replace(/\n/g, '<br>') + '<br>';
 						}
 						else {
 							// just add a space between captions


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/17](https://github.com/GSA/baselinealignment/security/code-scanning/17)

To fix this problem, all occurrences of `\n` in the `result` string should be replaced with `<br>`. This can be achieved by using a regular expression with the global (`g`) flag: `result.replace(/\n/g, '<br>')`. This change should be made in file `testfiles/assets/ableplayer/build/ableplayer.dist.js`, specifically on line 11193. No new imports or library dependencies are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
