### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js
+++ b/_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js
@@ -4457,7 +4457,7 @@
 					word = m ? m[1] : word;
 				}
 	
-				return word.replace('"', '');
+				return word.replace(/"/g, '');
 			} );
 	
 			search = '^(?=.*?'+a.join( ')(?=.*?' )+').*$';

--- a/_archive_reference/TT_TestPages/datatables.js
+++ b/_archive_reference/TT_TestPages/datatables.js
@@ -4469,7 +4469,7 @@
 					word = m ? m[1] : word;
 				}
 	
-				return word.replace('"', '');
+				return word.replace(/"/g, '');
 			} );
 	
 			search = '^(?=.*?'+a.join( ')(?=.*?' )+').*$';

--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -11190,7 +11190,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					if (typeof result === 'string') {
 						if (thisObj.lyricsMode) {
 							// add <br> BETWEEN each caption and WITHIN each caption (if payload includes "\n")
-							result = result.replace('\n','<br>') + '<br>';
+							result = result.replace(/\n/g,'<br>') + '<br>';
 						}
 						else {
 							// just add a space between captions

--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -11190,7 +11190,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					if (typeof result === 'string') {
 						if (thisObj.lyricsMode) {
 							// add <br> BETWEEN each caption and WITHIN each caption (if payload includes "\n")
-							result = result.replace('\n','<br>') + '<br>';
+							result = result.replace(/\n/g, '<br>') + '<br>';
 						}
 						else {
 							// just add a space between captions


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/11](https://github.com/GSA/baselinealignment/security/code-scanning/11)

To fix the issue, we should ensure that all occurrences of the double-quote character (`"`) are removed from the `word` string, not just the first one. This is best accomplished by replacing `.replace('"', '')` with `.replace(/"/g, '')`, which uses a regular expression with the global flag to remove all quotes.  
Only the specific line (4472) in `_archive_reference/TT_TestPages/datatables.js` needs to be modified. No additional imports or dependencies are needed, as this is native JS functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
