### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete string escaping or encoding

### DIFF
--- a/_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js
+++ b/_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js
@@ -4457,7 +4457,7 @@
 					word = m ? m[1] : word;
 				}
 	
-				return word.replace('"', '');
+				return word.replace(/"/g, '');
 			} );
 	
 			search = '^(?=.*?'+a.join( ')(?=.*?' )+').*$';


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/12](https://github.com/GSA/baselinealignment/security/code-scanning/12)

To fix the problem, the code should remove **all** occurrences of the double-quote character (`"`) from `word`, not just the first. The best way to do this in JavaScript is to use a regular expression with the global (`g`) flag: `word.replace(/"/g, '')`. This will ensure that any and all double-quote characters present in the string are removed, regardless of their number or position. Only the single line at 4460 in `_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js` needs to be changed. No new imports or helper functions are required, as `.replace` with a regex is standard.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
