### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/_archive_reference/TT_TestPages/datatables.js
+++ b/_archive_reference/TT_TestPages/datatables.js
@@ -14706,13 +14706,18 @@
 	
 	$.extend( DataTable.ext.type.search, {
 		html: function ( data ) {
-			return _empty(data) ?
-				data :
-				typeof data === 'string' ?
-					data
-						.replace( _re_new_lines, " " )
-						.replace( _re_html, "" ) :
-					'';
+			if (_empty(data)) {
+				return data;
+			}
+			if (typeof data === 'string') {
+				data = data.replace(_re_new_lines, " ");
+				let previous;
+				do {
+					previous = data;
+					data = data.replace(_re_html, "");
+				} while (data !== previous);
+			}
+			return data;
 		},
 	
 		string: function ( data ) {


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/8](https://github.com/GSA/baselinealignment/security/code-scanning/8)

To fix the issue, we need to ensure that all instances of unsafe HTML content are removed from the input string. This can be achieved by repeatedly applying the `_re_html` regular expression until no more matches are found. This approach ensures that nested or overlapping tags are fully sanitized. Additionally, we should consider using a well-tested library like `sanitize-html` for robust and comprehensive sanitization.

The fix involves modifying the `html` function to repeatedly apply the `_re_html` replacement until the input string no longer changes. This ensures that all HTML tags, including incomplete or nested ones, are removed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
