### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js
+++ b/_archive_reference/TT_TestPages/DataTables-1.10.18/js/jquery.dataTables.js
@@ -1512,7 +1512,12 @@
 	
 	
 	var _stripHtml = function ( d ) {
-		return d.replace( _re_html, '' );
+		var previous;
+		do {
+			previous = d;
+			d = d.replace( _re_html, '' );
+		} while (d !== previous);
+		return d;
 	};
 	
 	

--- a/_archive_reference/TT_TestPages/datatables.js
+++ b/_archive_reference/TT_TestPages/datatables.js
@@ -1524,7 +1524,12 @@
 	
 	
 	var _stripHtml = function ( d ) {
-		return d.replace( _re_html, '' );
+		var previous;
+		do {
+			previous = d;
+			d = d.replace( _re_html, '' );
+		} while (d !== previous);
+		return d;
 	};
 	
 	


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/1](https://github.com/GSA/baselinealignment/security/code-scanning/1)

To fix the issue, we need to ensure that `_stripHtml` removes all potentially unsafe HTML content, including nested or malformed tags. A robust approach is to apply the regular expression replacement repeatedly until no more matches are found. This ensures that all instances of HTML tags are removed, even if they are nested or malformed. Alternatively, we could use a well-tested library like `sanitize-html` for more comprehensive sanitization, but since we are limited to the provided code, we will implement the repeated replacement approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
