### PR TITLE
update rexml and webrick packages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.0)
-    ffi (1.15.0-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.9)
@@ -58,22 +56,23 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.3.3)
-      strscan
+    rexml (3.4.1)
     rouge (3.26.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc (2.4.0-x64-mingw32)
-      ffi (~> 1.9)
-    strscan (3.1.0)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
-    webrick (1.8.1)
+    webrick (1.9.1)
 
 PLATFORMS
-  x64-mingw32
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -82,8 +81,7 @@ DEPENDENCIES
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data
-  wdm (~> 0.1.1)
   webrick (~> 1.8)
 
 BUNDLED WITH
-   2.2.14
+   2.6.9


### PR DESCRIPTION
Update rexml and webrick packages to resolve dependabot alerts

https://github.com/GSA/baselinealignment/security/dependabot/7
https://github.com/GSA/baselinealignment/security/dependabot/6

[Preview Link](https://federalist-8faa193c-84af-4750-b121-b6934d6f4202.sites.pages.cloud.gov/preview/gsa/baselinealignment/update-rexml-http/)