### PR TITLE
Potential fix for code scanning alert no. 79: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/TF10/TC10.7-2.a-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.a-pass-1.html
@@ -59,8 +59,8 @@
             let number = document.getElementById("number").value;
             let time = document.getElementById("time").value;
 
-            document.getElementById("pizza-number").innerHTML = number;
-            document.getElementById("pizza-time").innerHTML = time;
+            document.getElementById("pizza-number").innerText = number;
+            document.getElementById("pizza-time").innerText = time;
 
             const pizza_price = 10; //dollars
             let total = "$" + parseInt(number * pizza_price) + ".89";

--- a/testfiles/TF10/TC10.7-2.a-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.a-pass-1.html
@@ -78,7 +78,7 @@
             document.getElementById("order-confirmation").setAttribute("hidden","hidden");
 
             //set refund amount
-            document.getElementById("pizza-refund").innerHTML = document.getElementById("pizza-total").innerText;
+            document.getElementById("pizza-refund").textContent = document.getElementById("pizza-total").innerText;
             let refund = document.getElementById("order-cancel");
 
             //show refund notification

--- a/testfiles/TF10/TC10.7-2.b-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.b-pass-1.html
@@ -74,7 +74,7 @@
                 //hide order form
                 document.getElementById("order-form").setAttribute("hidden","hidden");
 
-                document.getElementById("pizza-number").innerHTML = number;
+                document.getElementById("pizza-number").textContent = number;
                 document.getElementById("pizza-time").innerHTML = time;
 
                 const pizza_price = 10; //dollars

--- a/testfiles/TF10/TC10.7-all-fail-1.html
+++ b/testfiles/TF10/TC10.7-all-fail-1.html
@@ -56,8 +56,8 @@
             let number = document.getElementById("number").value;
             let time = document.getElementById("time").value;
 
-            document.getElementById("pizza-number").innerHTML = number;
-            document.getElementById("pizza-time").innerHTML = time;
+            document.getElementById("pizza-number").textContent = number;
+            document.getElementById("pizza-time").textContent = time;
 
             const pizza_price = 10; //dollars
             let total = "$" + parseInt(number * pizza_price) + ".89";


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/79](https://github.com/GSA/baselinealignment/security/code-scanning/79)

To fix the problem, we need to ensure that the user input is not interpreted as HTML. Instead of using `innerHTML`, we should use `innerText` or `textContent` to safely insert the text content into the DOM. This will prevent any HTML tags in the user input from being executed.

- Replace the usage of `innerHTML` with `innerText` for the `pizza-number` and `pizza-time` elements.
- Ensure that the input values are properly sanitized before being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
