### PR TITLE
Potential fix for code scanning alert no. 82: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/TF10/TC10.7-2.b-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.b-pass-1.html
@@ -75,7 +75,7 @@
                 document.getElementById("order-form").setAttribute("hidden","hidden");
 
                 document.getElementById("pizza-number").innerHTML = number;
-                document.getElementById("pizza-time").innerHTML = time;
+                document.getElementById("pizza-time").textContent = time;
 
                 const pizza_price = 10; //dollars
                 let total = "$" + parseInt(number * pizza_price) + ".89";


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/82](https://github.com/GSA/baselinealignment/security/code-scanning/82)

To fix the problem, we need to ensure that any user input is properly sanitized or escaped before being inserted into the DOM. In this case, we should use `textContent` instead of `innerHTML` to avoid interpreting the input as HTML. This will ensure that any special characters in the user input are treated as text rather than HTML.

- Change the assignment to `innerHTML` on line 78 to use `textContent` instead.
- This change should be made in the file `testfiles/TF10/TC10.7-2.b-pass-1.html`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
