### PR TITLE
Potential fix for code scanning alert no. 83: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/TF10/TC10.7-2.a-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.a-pass-1.html
@@ -78,7 +78,7 @@
             document.getElementById("order-confirmation").setAttribute("hidden","hidden");
 
             //set refund amount
-            document.getElementById("pizza-refund").innerHTML = document.getElementById("pizza-total").innerText;
+            document.getElementById("pizza-refund").textContent = document.getElementById("pizza-total").innerText;
             let refund = document.getElementById("order-cancel");
 
             //show refund notification


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/83](https://github.com/GSA/baselinealignment/security/code-scanning/83)

To fix the problem, we should replace the use of `innerHTML` with `textContent` when setting the content of the `pizza-refund` element. This ensures that the text is treated as plain text and not as HTML, thereby preventing any potential XSS vulnerabilities.

- Change the assignment to `document.getElementById("pizza-refund").textContent` instead of `innerHTML`.
- This change should be made on line 81 of the provided code snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
