### PR TITLE
Potential fix for code scanning alert no. 89: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/TF10/TC10.7-all-fail-1.html
+++ b/testfiles/TF10/TC10.7-all-fail-1.html
@@ -56,8 +56,8 @@
             let number = document.getElementById("number").value;
             let time = document.getElementById("time").value;
 
-            document.getElementById("pizza-number").innerHTML = number;
-            document.getElementById("pizza-time").innerHTML = time;
+            document.getElementById("pizza-number").textContent = number;
+            document.getElementById("pizza-time").textContent = time;
 
             const pizza_price = 10; //dollars
             let total = "$" + parseInt(number * pizza_price) + ".89";


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/89](https://github.com/GSA/baselinealignment/security/code-scanning/89)

To fix the problem, we need to ensure that the user input is properly sanitized or escaped before being inserted into the DOM. The best way to fix this issue without changing existing functionality is to use `textContent` instead of `innerHTML`. The `textContent` property will set the text content of the specified node, and any HTML tags in the input will be treated as text, not as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
