### PR TITLE
Potential fix for code scanning alert no. 90: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/TF10/TC10.7-all-fail-1.html
+++ b/testfiles/TF10/TC10.7-all-fail-1.html
@@ -57,7 +57,7 @@
             let time = document.getElementById("time").value;
 
             document.getElementById("pizza-number").innerHTML = number;
-            document.getElementById("pizza-time").innerHTML = time;
+            document.getElementById("pizza-time").textContent = time;
 
             const pizza_price = 10; //dollars
             let total = "$" + parseInt(number * pizza_price) + ".89";


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/90](https://github.com/GSA/baselinealignment/security/code-scanning/90)

To fix the problem, we need to ensure that any user input is properly sanitized or escaped before being inserted into the DOM. In this case, we should use `textContent` instead of `innerHTML` to avoid interpreting the input as HTML. This will ensure that any special characters in the user input are treated as text and not as HTML.

- Change the assignment to `innerHTML` to `textContent` for the `time` variable.
- Ensure that the same change is applied to any other similar assignments if they exist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
