### PR TITLE
Potential fix for code scanning alert no. 91: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/bootstrap.bundle.js
+++ b/assets/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/91](https://github.com/GSA/baselinealignment/security/code-scanning/91)

To fix this vulnerability, we must ensure that the value extracted from `data-target` (or `href`) is only ever used as a CSS selector, and never interpreted as HTML by jQuery. The best way to do this is to avoid using `$(selector)` directly, and instead use `document.querySelector(selector)` to obtain the target element, then wrap it in jQuery if needed. This prevents jQuery from interpreting the string as HTML and only allows valid selectors that resolve to actual DOM elements. 

Specifically, in the `Carousel._dataApiClickHandler` function, replace:
```js
var target = $(selector)[0];
```
with:
```js
var target = document.querySelector(selector);
```
and, if jQuery is needed, wrap `target` with `$(target)` (which is safe, as `target` is a DOM element, not a string).

No new imports or methods are needed, as `document.querySelector` is a standard DOM API.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
