### PR TITLE
Potential fix for code scanning alert no. 98: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -4752,7 +4752,7 @@ var AblePlayerInstances = [];
 				if (thisObj.hasAttr($(this),'data-src')) {
 					// this is the only required attribute
 					var $newSource = $('<source>',{
-						'src': $(this).attr('data-src')
+						'src': encodeURI($(this).attr('data-src'))
 					});
 					if (thisObj.hasAttr($(this),'data-type')) {
 						$newSource.attr('type',$(this).attr('data-type'));
@@ -4778,7 +4778,7 @@ var AblePlayerInstances = [];
 					thisObj.hasAttr($(this),'data-srclang')) {
 					// all required attributes are present
 					var $newTrack = $('<track>',{
-						'src': $(this).attr('data-src'),
+						'src': encodeURI($(this).attr('data-src')),
 						'kind': $(this).attr('data-kind'),
 						'srclang': $(this).attr('data-srclang')
 					});


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/98](https://github.com/GSA/baselinealignment/security/code-scanning/98)

To fix the problem, we should ensure that any value extracted from the DOM and used as an attribute value is properly sanitized or encoded to prevent the possibility of XSS. The best way to do this is to escape any meta-characters in the attribute value that could be interpreted as HTML or could break out of the attribute context. For URLs (such as `src`), this typically means using `encodeURI` or `encodeURIComponent` as appropriate. In this case, since `data-src` is used as the value for the `src` attribute, we should use `encodeURI` to encode the value before setting it as the attribute. This change should be made on line 4781, and similarly for line 4755 (for `<source>` elements), to ensure consistency and safety.

No new methods or imports are needed, as `encodeURI` is a built-in JavaScript function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
