### PR TITLE
Potential fix for code scanning alert no. 103: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -4828,7 +4828,8 @@ var AblePlayerInstances = [];
 				if (typeof itemLang !== 'undefined') {
 					nowPlayingSpan.attr('lang',itemLang);
 				}
-				nowPlayingSpan.html('<span>' + this.tt.selectedTrack + ':</span>' + itemTitle);
+				nowPlayingSpan.append($('<span>').text(this.tt.selectedTrack + ':'));
+				nowPlayingSpan.append(document.createTextNode(itemTitle));
 				this.$nowPlayingDiv.html(nowPlayingSpan);
 			}
 		}

--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -38,6 +38,22 @@
 var AblePlayerInstances = [];
 
 (function ($) {
+
+	// Helper function to validate media src URLs
+	function isSafeMediaSrc(src) {
+		// Only allow http(s), relative URLs, and disallow javascript: and data: schemes
+		// You may want to further restrict to only allow certain file extensions
+		var pattern = /^(https?:\/\/|\.{0,2}\/|\/)[^<>"]+$/i;
+		if (!pattern.test(src)) {
+			return false;
+		}
+		// Disallow javascript: and data: schemes explicitly
+		if (/^\s*(javascript:|data:)/i.test(src)) {
+			return false;
+		}
+		return true;
+	}
+
 	$(document).ready(function () {
 
 		$('video, audio').each(function (index, element) {
@@ -7497,7 +7513,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					origSrc = this.$sources[i].getAttribute('src');
 					descSrc = this.$sources[i].getAttribute('data-desc-src');
 					srcType = this.$sources[i].getAttribute('type');
-					if (descSrc) {
+					if (descSrc && isSafeMediaSrc(descSrc)) {
 						this.$sources[i].setAttribute('src',descSrc);
 						this.$sources[i].setAttribute('data-orig-src',origSrc);
 					}

--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -37,6 +37,23 @@
 // maintain an array of Able Player instances for use globally (e.g., for keeping prefs in sync)
 var AblePlayerInstances = [];
 
+// Helper function to sanitize media URLs for <source> elements
+function sanitizeMediaUrl(url) {
+	// Only allow http, https, or relative URLs
+	try {
+		var a = document.createElement('a');
+		a.href = url;
+		// If protocol is empty, it's a relative URL (safe)
+		// Otherwise, only allow http: or https:
+		if (!a.protocol || a.protocol === ':' || a.protocol === 'http:' || a.protocol === 'https:') {
+			return url;
+		}
+	} catch (e) {
+		// If URL parsing fails, treat as unsafe
+	}
+	return '';
+}
+
 (function ($) {
 	$(document).ready(function () {
 
@@ -7498,8 +7515,11 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					descSrc = this.$sources[i].getAttribute('data-desc-src');
 					srcType = this.$sources[i].getAttribute('type');
 					if (descSrc) {
-						this.$sources[i].setAttribute('src',descSrc);
-						this.$sources[i].setAttribute('data-orig-src',origSrc);
+						var safeDescSrc = sanitizeMediaUrl(descSrc);
+						if (safeDescSrc) {
+							this.$sources[i].setAttribute('src', safeDescSrc);
+							this.$sources[i].setAttribute('data-orig-src', origSrc);
+						}
 					}
 				}
 				this.swappingSrc = true;

--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -39,17 +39,12 @@ var AblePlayerInstances = [];
 
 // Helper function to sanitize media URLs for <source> elements
 function sanitizeMediaUrl(url) {
-	// Only allow http, https, or relative URLs
-	try {
-		var a = document.createElement('a');
-		a.href = url;
-		// If protocol is empty, it's a relative URL (safe)
-		// Otherwise, only allow http: or https:
-		if (!a.protocol || a.protocol === ':' || a.protocol === 'http:' || a.protocol === 'https:') {
-			return url;
-		}
-	} catch (e) {
-		// If URL parsing fails, treat as unsafe
+	// Only allow http, https, or relative URLs (no protocol-relative, javascript:, data:, etc.)
+	if (typeof url !== 'string') return '';
+	// Strictly allow only http(s) URLs or relative URLs
+	var pattern = /^(https?:\/\/[^\s]+|\.?\.?\/[^\s]+)$/i;
+	if (pattern.test(url)) {
+		return url;
 	}
 	return '';
 }

--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -7493,11 +7493,18 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 
 			if (this.usingAudioDescription()) {
 				// the described version is currently playing. Swap to non-described
+				// Helper function to validate media URLs
+				function isSafeMediaUrl(url) {
+					// Only allow http, https, or relative URLs (no javascript: or data:)
+					if (!url) return false;
+					var pattern = /^(https?:\/\/|\/|\.\/|\.\.\/)[^\s]*$/i;
+					return pattern.test(url);
+				}
 				for (i=0; i < this.$sources.length; i++) {
 					// for all <source> elements, replace src with data-orig-src
 					origSrc = this.$sources[i].getAttribute('data-orig-src');
 					srcType = this.$sources[i].getAttribute('type');
-					if (origSrc) {
+					if (origSrc && isSafeMediaUrl(origSrc)) {
 						this.$sources[i].setAttribute('src',origSrc);
 					}
 				}

--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -4829,7 +4829,9 @@ function sanitizeMediaUrl(url) {
 				if (typeof itemLang !== 'undefined') {
 					nowPlayingSpan.attr('lang',itemLang);
 				}
-				nowPlayingSpan.html('<span>' + this.tt.selectedTrack + ':</span>' + itemTitle);
+				var labelSpan = $('<span>').text(this.tt.selectedTrack + ':');
+				nowPlayingSpan.append(labelSpan);
+				nowPlayingSpan.append(document.createTextNode(itemTitle));
 				this.$nowPlayingDiv.html(nowPlayingSpan);
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/103](https://github.com/GSA/baselinealignment/security/code-scanning/103)

To fix the problem, we should ensure that the value read from the `data-desc-src` attribute is a safe, valid URL before setting it as the `src` attribute of a `<source>` element. The best way to do this is to validate that the URL is either relative or, if absolute, uses a safe protocol (such as `http:` or `https:`), and does not use dangerous protocols like `javascript:` or `data:` (unless explicitly allowed for media). We can implement a helper function, e.g., `sanitizeMediaUrl`, that checks the value and only returns it if it is safe; otherwise, it returns an empty string or does not set the attribute.

The changes should be made in the region where `descSrc` is read and set (lines 7498–7502). We will add a helper function (within the same file, above or within the relevant scope) and use it to sanitize `descSrc` before setting it as the `src` attribute.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
