### PR TITLE
Potential fix for code scanning alert no. 102: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -7476,11 +7476,18 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 
 			if (this.usingAudioDescription()) {
 				// the described version is currently playing. Swap to non-described
+				// Helper function to validate media URLs
+				function isSafeMediaUrl(url) {
+					// Only allow http, https, or relative URLs (no javascript: or data:)
+					if (!url) return false;
+					var pattern = /^(https?:\/\/|\/|\.\/|\.\.\/)[^\s]*$/i;
+					return pattern.test(url);
+				}
 				for (i=0; i < this.$sources.length; i++) {
 					// for all <source> elements, replace src with data-orig-src
 					origSrc = this.$sources[i].getAttribute('data-orig-src');
 					srcType = this.$sources[i].getAttribute('type');
-					if (origSrc) {
+					if (origSrc && isSafeMediaUrl(origSrc)) {
 						this.$sources[i].setAttribute('src',origSrc);
 					}
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/102](https://github.com/GSA/baselinealignment/security/code-scanning/102)

To fix this issue, we should ensure that the value read from `data-orig-src` is a safe, valid media URL before setting it as the `src` attribute. The best way is to validate that `origSrc` is a well-formed, trusted URL (e.g., only allowing `http:`, `https:`, or relative URLs, and never allowing `javascript:` or other dangerous schemes). This can be done by checking the value of `origSrc` before setting it. If the value does not match the expected pattern, we should skip setting it or handle it as an error.

The change should be made in the block where `origSrc` is set and used (lines 7481–7485). We can add a simple validation function (e.g., `isSafeMediaUrl`) and use it to check `origSrc` before calling `setAttribute('src', origSrc)`. If the value is not safe, we skip setting it.

We will define the `isSafeMediaUrl` function within the same scope as the `swapDescription` method, above the relevant code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
