### PR TITLE
Potential fix for code scanning alert no. 101: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -38,6 +38,22 @@
 var AblePlayerInstances = [];
 
 (function ($) {
+
+	// Helper function to validate media src URLs
+	function isSafeMediaSrc(src) {
+		// Only allow http(s), relative URLs, and disallow javascript: and data: schemes
+		// You may want to further restrict to only allow certain file extensions
+		var pattern = /^(https?:\/\/|\.{0,2}\/|\/)[^<>"]+$/i;
+		if (!pattern.test(src)) {
+			return false;
+		}
+		// Disallow javascript: and data: schemes explicitly
+		if (/^\s*(javascript:|data:)/i.test(src)) {
+			return false;
+		}
+		return true;
+	}
+
 	$(document).ready(function () {
 
 		$('video, audio').each(function (index, element) {
@@ -7497,7 +7513,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					origSrc = this.$sources[i].getAttribute('src');
 					descSrc = this.$sources[i].getAttribute('data-desc-src');
 					srcType = this.$sources[i].getAttribute('type');
-					if (descSrc) {
+					if (descSrc && isSafeMediaSrc(descSrc)) {
 						this.$sources[i].setAttribute('src',descSrc);
 						this.$sources[i].setAttribute('data-orig-src',origSrc);
 					}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/101](https://github.com/GSA/baselinealignment/security/code-scanning/101)

To fix the problem, we should ensure that the value assigned to the `src` attribute is safe and cannot be used to inject malicious content. The best way to do this is to validate the value of `descSrc` before setting it as the `src` attribute. Specifically, we should check that it is a valid URL for a media file (e.g., it starts with `http://`, `https://`, or is a relative path, and does not start with `javascript:` or other dangerous schemes). This can be done by adding a validation function that checks the value of `descSrc` before using it. The changes should be made in the block of code around line 7501 in `testfiles/assets/ableplayer/build/ableplayer.dist.js`. We will need to add a helper function (e.g., `isSafeMediaSrc`) and use it to guard the assignment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
