### PR TITLE
Potential fix for code scanning alert no. 99: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -4812,7 +4812,9 @@ var AblePlayerInstances = [];
 				if (typeof itemLang !== 'undefined') {
 					nowPlayingSpan.attr('lang',itemLang);
 				}
-				nowPlayingSpan.html('<span>' + this.tt.selectedTrack + ':</span>' + itemTitle);
+				var labelSpan = $('<span>').text(this.tt.selectedTrack + ':');
+				nowPlayingSpan.append(labelSpan);
+				nowPlayingSpan.append(document.createTextNode(itemTitle));
 				this.$nowPlayingDiv.html(nowPlayingSpan);
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/99](https://github.com/GSA/baselinealignment/security/code-scanning/99)

To fix this issue, we must ensure that any text content derived from the DOM and inserted into HTML is properly escaped, so that any HTML meta-characters are not interpreted as markup. The best way to do this in jQuery is to avoid using `.html()` for inserting untrusted text, and instead use `.text()` to insert plain text, or to set the text content of the relevant element. In this case, since the string being constructed includes both a label (with a `<span>`) and the untrusted `itemTitle`, we should construct the HTML such that only the trusted parts are inserted as HTML, and the untrusted `itemTitle` is inserted as text.

The fix is to:
- Create the outer `<span>` and the label `<span>` using jQuery.
- Set the label text and the item title text using `.text()`, not by concatenating into an HTML string.
- Append the label and item title as separate nodes to the outer span.
- Insert the constructed span into the DOM using `.html()` or `.empty().append()`.

This change should be made in the region around line 4815 in `testfiles/assets/ableplayer/build/ableplayer.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
