### PR TITLE
Potential fix for code scanning alert no. 96: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -4812,7 +4812,8 @@ var AblePlayerInstances = [];
 				if (typeof itemLang !== 'undefined') {
 					nowPlayingSpan.attr('lang',itemLang);
 				}
-				nowPlayingSpan.html('<span>' + this.tt.selectedTrack + ':</span>' + itemTitle);
+				nowPlayingSpan.append($('<span>').text(this.tt.selectedTrack + ':'));
+				nowPlayingSpan.append(document.createTextNode(itemTitle));
 				this.$nowPlayingDiv.html(nowPlayingSpan);
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/96](https://github.com/GSA/baselinealignment/security/code-scanning/96)

To fix the problem, we need to ensure that any text extracted from the DOM and later inserted as HTML is properly escaped to prevent interpretation of meta-characters as HTML. The best way to do this is to use jQuery's `.text()` method to set the text content, rather than `.html()`, for any untrusted data. In this case, we should create the `nowPlayingSpan` element, set its inner text using `.text()` for the untrusted `itemTitle`, and only use `.html()` for static, trusted markup. Alternatively, we can build the DOM structure using jQuery element creation and attribute setting, rather than string concatenation.

Specifically, in file `testfiles/assets/ableplayer/build/ableplayer.dist.js`, lines 4815-4816 should be changed so that `itemTitle` is set as text, not HTML. This can be done by creating a child span for the label, and then appending a text node for the title. No new imports are needed, as jQuery provides all required functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
