### PR TITLE
Potential fix for code scanning alert no. 78: DOM text reinterpreted as HTML

### DIFF
--- a/_archive_reference/TT_TestPages/4E_Pass2.html
+++ b/_archive_reference/TT_TestPages/4E_Pass2.html
@@ -2,6 +2,22 @@
 <html lang="en">
 <head>
 <title>On Focus Passing Example 2</title>
+<script type="text/javascript">
+function safeNavigate() {
+  var allowed = [
+    "4E_Pass2_home.html",
+    "4E_Pass2_menu.html",
+   "4E_Pass2_glossary.html",
+   "4E_Pass2_about.html"
+ ];
+ var sel = document.jump.menu;
+ var val = sel.options[sel.selectedIndex].value;
+ if (allowed.indexOf(val) !== -1) {
+   location = val;
+ }
+ // else do nothing or show an error
+}
+</script>
 </head>
 <body>
 <p><strong>*Note:</strong> this page provides only limited functionality, as described in the Trusted Tester training course.</p>
@@ -15,7 +31,7 @@
       <option value="4E_Pass2_glossary.html">Glossary</option>
       <option value="4E_Pass2_about.html">About Us</option>
     </select>
-    <input type="button" onClick="location=document.jump.menu.options[document.jump.menu.selectedIndex].value;" value="GO">
+    <input type="button" onClick="safeNavigate()" value="GO">
   </form>
 </p>
 </body>

--- a/testfiles/TF10/TC10.7-2.b-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.b-pass-1.html
@@ -75,7 +75,7 @@
                 document.getElementById("order-form").setAttribute("hidden","hidden");
 
                 document.getElementById("pizza-number").textContent = number;
-                document.getElementById("pizza-time").innerHTML = time;
+                document.getElementById("pizza-time").textContent = time;
 
                 const pizza_price = 10; //dollars
                 let total = "$" + parseInt(number * pizza_price) + ".89";

--- a/testfiles/TF10/TC10.7-2.c-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.c-pass-1.html
@@ -59,8 +59,8 @@
             let time = document.getElementById("time").value;
 
             //copy values from form
-            document.getElementById("cart-number").innerHTML = number;
-            document.getElementById("cart-time").innerHTML = time;
+            document.getElementById("cart-number").textContent = number;
+            document.getElementById("cart-time").textContent = time;
 
             //hide order form
             document.getElementById("order-form").setAttribute("hidden","hidden");
@@ -86,9 +86,9 @@
             let total = document.getElementById("cart-total").innerText;
 
             //copy values from cart
-            document.getElementById("pizza-number").innerHTML = number;
-            document.getElementById("pizza-time").innerHTML = time;
-            document.getElementById("pizza-total").innerHTML = total;
+            document.getElementById("pizza-number").textContent = number;
+            document.getElementById("pizza-time").textContent = time;
+            document.getElementById("pizza-total").textContent = total;
 
             //hide cart summary
             document.getElementById("order-summary").setAttribute("hidden","hidden");

--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -1078,12 +1078,16 @@ var AblePlayerInstances = [];
 				var $youTubeVideos = $(this).find('li[data-youtube-id]');
 				$youTubeVideos.each(function() {
 					var youTubeId = $(this).attr('data-youtube-id');
-					var youTubePoster = thisObj.getYouTubePosterUrl(youTubeId,'120');
-					var $youTubeImg = $('<img>',{
-						'src': youTubePoster,
-						'alt': ''
-					});
-					$(this).find('button').prepend($youTubeImg);
+					// Validate YouTube video ID: 11 chars, letters, numbers, - and _
+					if (/^[A-Za-z0-9_-]{11}$/.test(youTubeId)) {
+						var youTubePoster = thisObj.getYouTubePosterUrl(youTubeId,'120');
+						var $youTubeImg = $('<img>',{
+							'src': youTubePoster,
+							'alt': ''
+						});
+						$(this).find('button').prepend($youTubeImg);
+					}
+					// else: invalid ID, do not inject image
 				});
 
 				// add accessibility to the list markup


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/78](https://github.com/GSA/baselinealignment/security/code-scanning/78)

To fix the problem, ensure that only safe, expected URLs are used for navigation. The best way is to validate the selected value against a whitelist of allowed URLs before assigning it to `location`. This prevents the possibility of navigating to a `javascript:` URL or any other potentially dangerous value. The fix should be applied in the inline `onClick` handler in the HTML file. No external libraries are needed; a simple JavaScript check suffices. The code should only allow navigation if the selected value matches one of the known safe URLs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
