### PR TITLE
Potential fix for code scanning alert no. 94: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -4766,20 +4766,24 @@ var AblePlayerInstances = [];
 		if ($sourceSpans.length) {
 			$sourceSpans.each(function() {
 				if (thisObj.hasAttr($(this),'data-src')) {
-					// this is the only required attribute
-					var $newSource = $('<source>',{
-						'src': $(this).attr('data-src')
-					});
-					if (thisObj.hasAttr($(this),'data-type')) {
-						$newSource.attr('type',$(this).attr('data-type'));
+					var dataSrc = $(this).attr('data-src');
+					if (isSafeMediaSrc(dataSrc)) {
+						// this is the only required attribute
+						var $newSource = $('<source>',{
+							'src': dataSrc
+						});
+						if (thisObj.hasAttr($(this),'data-type')) {
+							$newSource.attr('type',$(this).attr('data-type'));
+						}
+						if (thisObj.hasAttr($(this),'data-desc-src')) {
+							$newSource.attr('data-desc-src',$(this).attr('data-desc-src'));
+						}
+						if (thisObj.hasAttr($(this),'data-sign-src')) {
+							$newSource.attr('data-sign-src',$(this).attr('data-sign-src'));
+						}
+						thisObj.$media.append($newSource);
 					}
-					if (thisObj.hasAttr($(this),'data-desc-src')) {
-						$newSource.attr('data-desc-src',$(this).attr('data-desc-src'));
-					}
-					if (thisObj.hasAttr($(this),'data-sign-src')) {
-						$newSource.attr('data-sign-src',$(this).attr('data-sign-src'));
-					}
-					thisObj.$media.append($newSource);
+					// else: invalid src, do not add
 				}
 			});
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/94](https://github.com/GSA/baselinealignment/security/code-scanning/94)

To fix the problem, we should validate the value of `data-src` before using it as the `src` attribute of the new `<source>` element. The file already defines a helper function `isSafeMediaSrc(src)` for this purpose. The best fix is to call this function on the value of `data-src` before creating and appending the `<source>` element. If the value is not safe, we should skip creating the element (or handle it as appropriate, e.g., log a warning). This change should be made in the block of code starting at line 4767, specifically where the new `<source>` element is created.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
