### PR TITLE
Potential fix for code scanning alert no. 95: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -4793,8 +4793,13 @@ var AblePlayerInstances = [];
 					thisObj.hasAttr($(this),'data-kind') &&
 					thisObj.hasAttr($(this),'data-srclang')) {
 					// all required attributes are present
+					var dataSrc = $(this).attr('data-src');
+					if (typeof isSafeMediaSrc === 'function' && !isSafeMediaSrc(dataSrc)) {
+						// Skip this track if src is not safe
+						return;
+					}
 					var $newTrack = $('<track>',{
-						'src': $(this).attr('data-src'),
+						'src': dataSrc,
 						'kind': $(this).attr('data-kind'),
 						'srclang': $(this).attr('data-srclang')
 					});


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/95](https://github.com/GSA/baselinealignment/security/code-scanning/95)

To fix the problem, we should validate the value of `data-src` before using it as the `src` attribute for the new `<track>` element. The best way to do this is to use the existing `isSafeMediaSrc` function to check the value. If the value is not safe, we should skip creating the `<track>` element or handle the error appropriately. This change should be made in the block where the new `<track>` element is created (lines 4796-4800). We need to retrieve the value of `data-src`, validate it, and only proceed if it passes the check. No new imports are needed, as the helper function is already defined in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
