### PR TITLE
Potential fix for code scanning alert no. 102: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.js
@@ -7532,7 +7532,10 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					origSrc = this.$sources[i].getAttribute('data-orig-src');
 					srcType = this.$sources[i].getAttribute('type');
 					if (origSrc && isSafeMediaUrl(origSrc)) {
-						this.$sources[i].setAttribute('src',origSrc);
+						var safeOrigSrc = sanitizeMediaUrl(origSrc);
+						if (safeOrigSrc) {
+							this.$sources[i].setAttribute('src', safeOrigSrc);
+						}
 					}
 				}
 				// No need to check for this.initializing


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/102](https://github.com/GSA/baselinealignment/security/code-scanning/102)

To fix the problem, we should ensure that any value read from the DOM and set as the `src` attribute is properly sanitized. The `sanitizeMediaUrl` function is already defined and used elsewhere in the code for this purpose. The best fix is to apply `sanitizeMediaUrl` to `origSrc` before setting it as the `src` attribute. This will ensure that only safe URLs are used, preventing potential XSS or other injection attacks. Specifically, in the block where `origSrc` is set as the `src` attribute (line 7535), we should sanitize `origSrc` first and only set it if the sanitized value is non-empty.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
