### PR TITLE
Potential fix for code scanning alert no. 100: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -7518,8 +7518,12 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					// for all <source> elements, replace src with data-orig-src
 					origSrc = this.$sources[i].getAttribute('data-orig-src');
 					srcType = this.$sources[i].getAttribute('type');
-					if (origSrc && isSafeMediaSrc(origSrc)) {
-						this.$sources[i].setAttribute('src',origSrc);
+					if (
+						typeof origSrc === 'string' &&
+						isSafeMediaSrc(origSrc) &&
+						!/[<>"'`]/.test(origSrc) // extra check: disallow HTML meta-characters
+					) {
+						this.$sources[i].setAttribute('src', origSrc);
 					}
 				}
 				// No need to check for this.initializing


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/100](https://github.com/GSA/baselinealignment/security/code-scanning/100)

To fix the problem, we should ensure that the value read from `data-orig-src` is strictly validated before being set as the `src` attribute. The current `isSafeMediaSrc` function is a good start, but we should further sanitize the value to ensure it cannot contain any HTML meta-characters or dangerous schemes. Additionally, we should consider using DOM methods that do not interpret the value as HTML, and avoid setting the `src` attribute if the value is not strictly safe. The fix should be applied in the block where `origSrc` is read and set (lines 7519–7522), and the validation function should be reviewed for completeness.

If the validation function is already robust, the main fix is to ensure that it is always used before setting the attribute, and possibly to escape or reject any suspicious values. No changes to functionality are needed, only to security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
