### PR TITLE
Potential fix for code scanning alert no. 115: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -39,6 +39,16 @@ var AblePlayerInstances = [];
 
 (function ($) {
 
+	// Helper function to encode HTML entities
+	function escapeHtml(text) {
+		return String(text)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	}
+
 	// Helper function to validate media src URLs
 	function isSafeMediaSrc(src) {
 		// Only allow http(s), relative URLs, and disallow javascript: and data: schemes
@@ -4783,7 +4793,7 @@ var AblePlayerInstances = [];
 					if (isSafeMediaSrc(dataSrc)) {
 						// this is the only required attribute
 						var $newSource = $('<source>',{
-							'src': dataSrc
+							'src': escapeHtml(dataSrc)
 						});
 						if (thisObj.hasAttr($(this),'data-type')) {
 							$newSource.attr('type',$(this).attr('data-type'));


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/115](https://github.com/GSA/baselinealignment/security/code-scanning/115)

To fix the problem, we should ensure that the value assigned to the `src` attribute is both validated and properly encoded to prevent any possibility of XSS or other injection attacks. The current validation function, `isSafeMediaSrc`, should be used to gate the assignment, which is already done. However, to further harden the code, we should explicitly escape any meta-characters in the `dataSrc` value before using it as an attribute value, even after validation. This can be done by using a utility function to encode HTML entities in the string, or by using jQuery's attribute setter, which already escapes values. Since jQuery's attribute setter is safe for attribute values, the main risk is if the validation function is bypassed. Therefore, we should ensure that the validation function is not bypassable and, optionally, add a utility to encode the value as a defense-in-depth measure.

**Required changes:**
- Add a utility function to encode HTML entities (if not already present).
- Use this function to encode `dataSrc` before assigning it to the `src` attribute.
- Ensure that the validation function is not bypassable (already appears robust).

**Files/regions to change:**
- In `testfiles/assets/ableplayer/build/ableplayer.dist.js`, around line 4786, encode `dataSrc` before using it.

**Methods/imports/definitions needed:**
- Add a function to encode HTML entities (e.g., `escapeHtml`).
- Use this function when setting the `src` attribute.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
