### PR TITLE
Autoalert staging 2

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -4826,7 +4826,7 @@ var AblePlayerInstances = [];
 						return;
 					}
 					var $newTrack = $('<track>');
-					$newTrack.attr('src', dataSrc);
+					$newTrack.attr('src', escapeHtml(dataSrc));
 					$newTrack.attr('kind', $(this).attr('data-kind'));
 					$newTrack.attr('srclang', $(this).attr('data-srclang'));
 					if (thisObj.hasAttr($(this),'data-label')) {


### PR DESCRIPTION
Contains code scan fixes for 'DOM reinterpreted as html' errors