### PR TITLE
Potential fix for code scanning alert no. 101: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/assets/ableplayer/build/ableplayer.dist.js
+++ b/testfiles/assets/ableplayer/build/ableplayer.dist.js
@@ -7550,7 +7550,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 					descSrc = this.$sources[i].getAttribute('data-desc-src');
 					srcType = this.$sources[i].getAttribute('type');
 					if (descSrc && isSafeMediaSrc(descSrc)) {
-						this.$sources[i].setAttribute('src',descSrc);
+						this.$sources[i].setAttribute('src', escapeHtml(descSrc));
 						this.$sources[i].setAttribute('data-orig-src',origSrc);
 					}
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/101](https://github.com/GSA/baselinealignment/security/code-scanning/101)

To fix the problem, we should ensure that any value taken from the DOM and set as an attribute (especially one that could be interpreted as HTML or a URL) is properly escaped to prevent XSS vulnerabilities. In this case, before setting `descSrc` as the value of the `src` attribute, we should escape meta-characters using the existing `escapeHtml` helper function, just as is done for `origSrc` in the previous block. This change should be made in the block of code starting at line 7546, specifically on line 7553, in the file `testfiles/assets/ableplayer/build/ableplayer.dist.js`. No new imports or methods are needed, as `escapeHtml` is already defined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
